### PR TITLE
Logger wrapper now uses python logging facilities.

### DIFF
--- a/cherry/debug.py
+++ b/cherry/debug.py
@@ -60,12 +60,15 @@ def debug(log_dir='./'):
         log_file = open(log_file, mode='a', buffering=1, encoding='utf-8')
         stdout_write = sys.stdout.write
         stderr_write = sys.stderr.write
+
         def custom_stdout_write(*args, **kwargs):
             stdout_write(*args, **kwargs)
             log_file.write(*args, **kwargs)
+
         def custom_stderr_write(*args, **kwargs):
             stderr_write(*args, **kwargs)
             log_file.write(*args, **kwargs)
+
         global print
         print = custom_stdout_write
         sys.stdout.write = custom_stdout_write

--- a/cherry/debug.py
+++ b/cherry/debug.py
@@ -17,6 +17,7 @@ IS_DEBUGGING = False
 # Sets up general debugger
 logger = logging.getLogger('cherry')
 logger.setLevel(logging.INFO)
+logger.propagate = False
 
 # Handler for normal printing
 fmt = logging.Formatter(fmt='%(message)s', datefmt='')

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -32,7 +32,6 @@ class Logger(Wrapper):
 
         if logger is None:
             logger = cherry.debug.logger
-
         self.logger = logger
 
     def _episodes_length_rewards(self, rewards, dones):

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -6,6 +6,7 @@ from .base import Wrapper
 
 import cherry
 
+
 class Logger(Wrapper):
 
     """

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -24,24 +24,25 @@ class Logger(Wrapper):
         self.ep_interval = episode_interval
         self.values = {}
         self.values_idx = {}
+
         if title is None:
             if hasattr(env, 'spec') and hasattr(env.spec, 'id'):
                 title = env.spec.id
             else:
                 title = ''
         self.title = title
+
         if logger is None:
-            logging.basicConfig(level=logging.WARNING)
             logger = logging.getLogger('cherry')
             logger.setLevel(logging.INFO)
+            if not logger.hasHandlers():
+                fmt = logging.Formatter(fmt='%(message)s', datefmt='')
+                print_handler = logging.StreamHandler(sys.stdout)
+                print_handler.setFormatter(fmt)
+                print_handler.setLevel(logging.INFO)
+                logger.addHandler(print_handler)
             logger.propagate = False
-            '''
-            fmt = logging.Formatter(fmt='%(message)s', datefmt='')
-            print_handler = logging.StreamHandler(sys.stdout)
-            print_handler.setFormatter(fmt)
-            print_handler.setLevel(logging.INFO)
-            logger.addHandler(print_handler)
-            '''
+    
         self.logger = logger
 
     def _episodes_length_rewards(self, rewards, dones):

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -4,6 +4,8 @@ from statistics import mean, pstdev
 
 from .base import Wrapper
 
+import logging
+
 
 class Logger(Wrapper):
 
@@ -11,7 +13,7 @@ class Logger(Wrapper):
     Tracks and prints some common statistics about the environment.
     """
 
-    def __init__(self, env, interval=1000, episode_interval=10, title=None):
+    def __init__(self, env, interval=1000, episode_interval=10, title=None, logger=None):
         super(Logger, self).__init__(env)
         self.num_steps = 0
         self.num_episodes = 0
@@ -27,6 +29,10 @@ class Logger(Wrapper):
             else:
                 title = ''
         self.title = title
+        if logger is None:
+            logger = logging.getLogger('cherry')
+            logger.setLevel(logging.INFO)
+        self.logger = logger
 
     def _episodes_length_rewards(self, rewards, dones):
         episode_rewards = []
@@ -133,7 +139,7 @@ class Logger(Wrapper):
             msg, ep_stats, steps_stats = self.stats()
             info['logger_steps_stats'] = steps_stats
             info['logger_ep_stats'] = ep_stats
-            print(msg)
+            self.logger.info(msg)
         if done:
             self.num_episodes += 1
         return state, reward, done, info

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -4,9 +4,7 @@ from statistics import mean, pstdev
 
 from .base import Wrapper
 
-import sys
-import logging
-
+import cherry
 
 class Logger(Wrapper):
 
@@ -33,16 +31,8 @@ class Logger(Wrapper):
         self.title = title
 
         if logger is None:
-            logger = logging.getLogger('cherry')
-            logger.setLevel(logging.INFO)
-            if not logger.hasHandlers():
-                fmt = logging.Formatter(fmt='%(message)s', datefmt='')
-                print_handler = logging.StreamHandler(sys.stdout)
-                print_handler.setFormatter(fmt)
-                print_handler.setLevel(logging.INFO)
-                logger.addHandler(print_handler)
-            logger.propagate = False
-    
+            logger = cherry.debug.logger
+
         self.logger = logger
 
     def _episodes_length_rewards(self, rewards, dones):

--- a/cherry/envs/logger_wrapper.py
+++ b/cherry/envs/logger_wrapper.py
@@ -4,6 +4,7 @@ from statistics import mean, pstdev
 
 from .base import Wrapper
 
+import sys
 import logging
 
 
@@ -30,8 +31,17 @@ class Logger(Wrapper):
                 title = ''
         self.title = title
         if logger is None:
+            logging.basicConfig(level=logging.WARNING)
             logger = logging.getLogger('cherry')
             logger.setLevel(logging.INFO)
+            logger.propagate = False
+            '''
+            fmt = logging.Formatter(fmt='%(message)s', datefmt='')
+            print_handler = logging.StreamHandler(sys.stdout)
+            print_handler.setFormatter(fmt)
+            print_handler.setLevel(logging.INFO)
+            logger.addHandler(print_handler)
+            '''
         self.logger = logger
 
     def _episodes_length_rewards(self, rewards, dones):

--- a/cherry/envs/visdom_logger_wrapper.py
+++ b/cherry/envs/visdom_logger_wrapper.py
@@ -34,7 +34,7 @@ class VisdomLogger(Logger):
                  episode_interval=10,
                  render=True,
                  title=None,
-                 Logger=None
+                 logger=None
                  ):
         super(VisdomLogger, self).__init__(env=env,
                                            interval=interval,

--- a/cherry/envs/visdom_logger_wrapper.py
+++ b/cherry/envs/visdom_logger_wrapper.py
@@ -33,12 +33,14 @@ class VisdomLogger(Logger):
                  interval=1000,
                  episode_interval=10,
                  render=True,
-                 title=None
+                 title=None,
+                 Logger=None
                  ):
         super(VisdomLogger, self).__init__(env=env,
                                            interval=interval,
                                            episode_interval=episode_interval,
-                                           title=title)
+                                           title=title,
+                                           Logger=Logger)
         self.ep_actions = []
         self.full_ep_actions = []
         self.ep_renders = []

--- a/cherry/envs/visdom_logger_wrapper.py
+++ b/cherry/envs/visdom_logger_wrapper.py
@@ -40,7 +40,7 @@ class VisdomLogger(Logger):
                                            interval=interval,
                                            episode_interval=episode_interval,
                                            title=title,
-                                           Logger=Logger)
+                                           logger=logger)
         self.ep_actions = []
         self.full_ep_actions = []
         self.ep_renders = []

--- a/tests/unit/debug_logger_tests.py
+++ b/tests/unit/debug_logger_tests.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import unittest
+import cherry as ch
+import cherry.envs as envs
+import logging
+import os
+
+
+class TestDebugLogger(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_propagation(self):
+        with self.assertLogs('cherry', level='INFO') as context:
+            logging.getLogger('cherry').critical('Rainier cherries rule.')
+            ch.debug.logger.error('Yann LeCun is notably ambivalent towards cherries.')
+            logging.getLogger('cherry').info('The average cherry tree yields ~7,000 cherries annually.')
+            ch.debug.logger.debug('Washington, Oregon and California combine to make 94% of the United States sweet cherries.')
+            logging.basicConfig(stream=open(os.devnull,'w'))
+            logging.critical('Cherries are typically harvested via a mechanical tree shaker and tarp.')
+            logging.warning('The word cherry is thought to be derived from the name of the Greek city Cerasus.')
+            logging.debug('The record for cherry pit spitting distance (w/ no running start) is 93 feet, held by Brian Krause')
+        
+        self.assertEqual(context.output, ['CRITICAL:cherry:Rainier cherries rule.',
+                                          'ERROR:cherry:Yann LeCun is notably ambivalent towards cherries.',
+                                          'INFO:cherry:The average cherry tree yields ~7,000 cherries annually.'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Logger wrapper now allows users more flexibility in when, where, and what information gets logged by integrating Python's logging facilities. Users can optionally pass in a Python logger object or default to a standard logging object that causes the wrapper to behave, from the user's standpoint, exactly the same as before (output goes to sys.stdout, logging level set to INFO). Note that the logger name 'cherry' is the same as in cherry/debug.py and multiple calls to logging.getLogger(__name__) with the same __name__ return a reference to the same logging object, so importing debug will modify the behavior slightly. We should either add the printHandler once debug() has been called or do the same when constructing the default logger in cherry/logger_wrapper.py. 

[EDIT] Set propagate to false to avoid having messages print twice. Ancestors ignore level and filters of propagated messages, so logging events handled by logger 'cherry' were also being handled by the root logger. The root logger is given a handler by basicConfig, which is called by any of the logging event functions if root has no handlers.